### PR TITLE
Search endpoint2

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,24 +111,66 @@ One of these arrays can be empty, but not both
 }
 ```
 #### Response
-Returns any user that contains any of the attributes selected in the search
-```
+Returns any users with partial matches of the selected search attributes
+```json
 {
-  data: [{
-​    "id": "1",
-​    "username": "Chipmunk",
-    "bio": "I'm the best one you could possibly hire",
-​    "skills": ["javascript", "react"],
-​    "values": ["writing", "teamwork"]
-  }, {
-​    "id": "2",
-​    "username": "time-traveler",
-    "bio": "I'm the best one you could possibly hire",
-​    "skills": ["javascript", "react"],
-​    "values": ["paired programming", "magic"]
-  }]
+    "success": true,
+    "data": [
+        {
+            "id": 1,
+            "username": "Chipmunk",
+            "email": "gaby@hireup.com",
+            "bio": "Noodle's mom!",
+            "skills": [
+                {
+                    "attribute": "rails"
+                },
+                {
+                    "attribute": "ruby"
+                }
+            ],
+            "values": [
+                {
+                    "attribute": "creativity"
+                }
+            ]
+        },
+        {
+            "id": 2,
+            "username": "Anonymous Giraffe",
+            "email": "ruthie@hireup.com",
+            "bio": "Noodle's mom's accountabilabuddy!",
+            "skills": [
+                {
+                    "attribute": "rails"
+                },
+                {
+                    "attribute": "flask"
+                }
+            ],
+            "values": [
+                {
+                    "attribute": "creativity"
+                },
+                {
+                    "attribute": "mentorship"
+                }
+            ]
+        }
+    ]
 }
 ```
+
+A request body that does not specify any skills or values to search for will return an error message:
+```json
+{
+  "success": false,
+  "error": 400,
+  "errors": "At least one skill or value id must be specified in order to filter applicant search results."
+}
+```
+
+
 #### GET `/api/v1/applicants/:applicant_id`
 #### Response
 ```

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -41,6 +41,6 @@ def create_app(config_name='default'):
     api.add_resource(MessageResource, '/api/v1/messages/<message_id>')
     api.add_resource(MessagesResource, '/api/v1/messages')
     api.add_resource(SearchOptionsResource, '/api/v1/search-options')
-    api.add_resource(SearchResultsResource, '/api/v1/search')
+    api.add_resource(SearchResultsResource, '/api/v1/applicants/search')
 
     return app

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -29,6 +29,7 @@ def create_app(config_name='default'):
     @app.route('/')
     def root():
         return 'Hello World!'
+        # this is where we can eventually add documentation to display on the deployed site
 
     # Add resources
     from api.resources.applicants import ApplicantsResource, ApplicantResource

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -34,11 +34,13 @@ def create_app(config_name='default'):
     from api.resources.applicants import ApplicantsResource, ApplicantResource
     from api.resources.messages import MessagesResource, MessageResource
     from api.resources.search_options import SearchOptionsResource
+    from api.resources.search_results import SearchResultsResource
 
     api.add_resource(ApplicantResource, '/api/v1/applicants/<applicant_id>')
     api.add_resource(ApplicantsResource, '/api/v1/applicants')
     api.add_resource(MessageResource, '/api/v1/messages/<message_id>')
     api.add_resource(MessagesResource, '/api/v1/messages')
     api.add_resource(SearchOptionsResource, '/api/v1/search-options')
+    api.add_resource(SearchResultsResource, '/api/v1/search')
 
     return app

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from api import db
 from api.database.models import Applicant
 
-def _search_results_payload(results):
+def _search_results_payload(applicants):
 
     return {
         'id': applicant.id,
@@ -18,3 +18,30 @@ def _search_results_payload(results):
         'skills': [skill.name for skill in applicant.skills],
         'values': [value.name for value in applicant.values],
     }
+
+class SearchResultsResource(Resource):
+    """
+    this Resource file is for our /applicants/search endpoint
+    """
+
+    def get(self, **kwargs):
+        import pdb; pdb.set_trace()
+        # set empty search results array
+        # if skills array and values array both have contents
+            # iterate over skills ids to find applicants with each skill
+            # push resulting collection of applicants into search results array
+            # iterate over values ids to find applicants with each value
+            # push resulting collection of applicants into search results array
+            # unique the resulting collection of applicants
+        # if skills array empty and values array has contents
+            # ^^ do the above just with values array
+        # if values array empty and skills array has contents
+            # ^^ do the above just with skills array
+        # if both arrays empty
+            # error
+        # end
+
+        skill_ids = request.json['skills']
+        value_ids = request.json['values']
+
+        applicants = db.engine.execute(f"SELECT DISTINCT applicants.* FROM applicants JOIN applicant_skills ON applicants.id = applicant_skills.applicant_id WHERE applicant_skills.skill_id = {skill_id};")

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from api import db
 from api.database.models import Applicant
 
+# HELPER METHODS
 def _search_results_payload(applicants):
 
     return {
@@ -19,29 +20,44 @@ def _search_results_payload(applicants):
         'values': [value.name for value in applicant.values],
     }
 
+def _find_applicants_with_skill(skill_id):
+    return db.engine.execute(f"SELECT DISTINCT applicants.* FROM applicants JOIN applicant_skills ON applicants.id = applicant_skills.applicant_id WHERE applicant_skills.skill_id = {skill_id};")
+
+
 class SearchResultsResource(Resource):
     """
     this Resource file is for our /applicants/search endpoint
     """
 
     def get(self, **kwargs):
-        import pdb; pdb.set_trace()
+        skill_ids = request.json['skills']
+        value_ids = request.json['values']
+        applicants_results = []
         # set empty search results array
         # if skills array and values array both have contents
+        if skill_ids and value_ids:
+            import pdb; pdb.set_trace()
+            for skill_id in skill_ids:
+                applicant_results.append(_find_applicants_with_skill(skill_id))
             # iterate over skills ids to find applicants with each skill
             # push resulting collection of applicants into search results array
             # iterate over values ids to find applicants with each value
             # push resulting collection of applicants into search results array
             # unique the resulting collection of applicants
         # if skills array empty and values array has contents
+        elif skill_ids and not value_ids:
+            import pdb; pdb.set_trace()
+
             # ^^ do the above just with values array
         # if values array empty and skills array has contents
+        elif value_ids and not skill_ids:
+            import pdb; pdb.set_trace()
             # ^^ do the above just with skills array
+        else:
+            import pdb; pdb.set_trace()
         # if both arrays empty
             # error
-        # end
 
-        skill_ids = request.json['skills']
-        value_ids = request.json['values']
+
 
         applicants = db.engine.execute(f"SELECT DISTINCT applicants.* FROM applicants JOIN applicant_skills ON applicants.id = applicant_skills.applicant_id WHERE applicant_skills.skill_id = {skill_id};")

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -27,51 +27,33 @@ def _create_sql_query(skill_ids, value_ids):
     value_ids_length = len(value_ids) - 1
     if skill_ids and value_ids:
         for skill_id in skill_ids:
-        # for i in range(skill_ids_length):
             sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
         for value_id in value_ids:
-        # for i, value_id in enumerate(value_ids):
-        # for i in range(value_ids_length):
-            # if value_ids[i + 1] != None:
             if value_id != value_ids[value_ids_length]:
                 sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
             else:
                 sql_query = sql_query + f"applicant_values.value_id = {value_id}"
-            import pdb; pdb.set_trace()
+        return sql_query
+    elif skill_ids and not value_ids:
+        for skill_id in skill_ids:
+            if skill_id != skill_ids[skill_ids_length]:
+                sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
+            else:
+                sql_query = sql_query + f"applicant_skills.skill_id = {skill_id}"
+        return sql_query
+    elif value_ids and not skill_ids:
+        for value_id in value_ids:
+            if value_id != value_ids[value_ids_length]:
+                sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
+            else:
+                sql_query = sql_query + f"applicant_values.value_id = {value_id}"
+        import pdb; pdb.set_trace()
+        return sql_query
 
-####HAVING ISSUES WITH ITERATING THROUGH IDS AND PRODUCING SOMETHING DIFFERENT FOR LAST ID IN ARRAY
-
-
-        # return sql_query
-        # for i in range(value_ids_length):
-        #     if value_ids[i + 1] is not None:
-        #         sql_query = sql_query + f"applicant_values.value_id - {value_ids[i]} OR "
-        #     else:
-        #         sql_query = sql_query + f"applicant_values.value_id - {value_ids[i]}"
-        # return sql_query
-    # elif skill_ids and not value_ids:
-    #     for i in range(skill_ids_length):
-    #         if skill_ids[i + 1] != None:
-    #             sql_query = sql_query + f"applicant_skills.skill_id - {skill_ids[i]} OR "
-    #         else:
-    #             sql_query = sql_query + f"applicant_skills.skill_id - {skill_ids[i]}"
-    #     return sql_query
-    # elif value_ids and not skill_ids:
-    #     for i in range(value_ids_length):
-    #         if value_ids[i + 1] != None:
-    #             sql_query = sql_query + f"applicant_values.value_id - {value_ids[i]} OR "
-    #         else:
-    #             sql_query = sql_query + f"applicant_values.value_id - {value_ids[i]}"
-    #     return sql_query
-
-
-    # for value_id in value_ids:
-    #     sq
-    # # for each skill id:
-    #     sql query << "OR applicant_skills.skill_id = {id}"
-    # return sql_query
-
-
+#### NEXT STEPS
+    # render error when no ids passed at all (line 73)
+    # make sure non-erroneous input renders correctly
+## add error handling for when "skills" and/or "values" JSON body keys are not present
 
 class SearchResultsResource(Resource):
     """

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -6,11 +6,11 @@ from flask_restful import Resource, abort
 from sqlalchemy.orm.exc import NoResultFound
 
 from api import db
-from api.database.models import Applicant, ApplicantSkill, ApplicantValue
+from api.database.models import Applicant, Skill, Value
 
 # HELPER METHODS
 def _applicant_payload(applicant):
-    import pdb; pdb.set_trace()
+
     return {
         'id': applicant.id,
         'username': applicant.username,
@@ -20,33 +20,33 @@ def _applicant_payload(applicant):
         'values': [value.name for value in applicant.values],
     }
 
-def _create_sql_query(skill_ids, value_ids):
-    sql_query = "SELECT DISTINCT applicants.* FROM applicants JOIN applicant_skills ON applicants.id = applicant_skills.applicant_id JOIN applicant_values ON applicants.id = applicant_values.applicant_id WHERE "
-    skill_ids_length = len(skill_ids) - 1
-    value_ids_length = len(value_ids) - 1
-    if skill_ids and value_ids:
-        for skill_id in skill_ids:
-            sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
-        for value_id in value_ids:
-            if value_id != value_ids[value_ids_length]:
-                sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
-            else:
-                sql_query = sql_query + f"applicant_values.value_id = {value_id}"
-        return sql_query
-    elif skill_ids and not value_ids:
-        for skill_id in skill_ids:
-            if skill_id != skill_ids[skill_ids_length]:
-                sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
-            else:
-                sql_query = sql_query + f"applicant_skills.skill_id = {skill_id}"
-        return sql_query
-    elif value_ids and not skill_ids:
-        for value_id in value_ids:
-            if value_id != value_ids[value_ids_length]:
-                sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
-            else:
-                sql_query = sql_query + f"applicant_values.value_id = {value_id}"
-        return sql_query
+# def _create_sql_query(skill_ids, value_ids):
+#     sql_query = "SELECT DISTINCT applicants.* FROM applicants JOIN applicant_skills ON applicants.id = applicant_skills.applicant_id JOIN applicant_values ON applicants.id = applicant_values.applicant_id WHERE "
+#     skill_ids_length = len(skill_ids) - 1
+#     value_ids_length = len(value_ids) - 1
+#     if skill_ids and value_ids:
+#         for skill_id in skill_ids:
+#             sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
+#         for value_id in value_ids:
+#             if value_id != value_ids[value_ids_length]:
+#                 sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
+#             else:
+#                 sql_query = sql_query + f"applicant_values.value_id = {value_id}"
+#         return sql_query
+#     elif skill_ids and not value_ids:
+#         for skill_id in skill_ids:
+#             if skill_id != skill_ids[skill_ids_length]:
+#                 sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
+#             else:
+#                 sql_query = sql_query + f"applicant_skills.skill_id = {skill_id}"
+#         return sql_query
+#     elif value_ids and not skill_ids:
+#         for value_id in value_ids:
+#             if value_id != value_ids[value_ids_length]:
+#                 sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
+#             else:
+#                 sql_query = sql_query + f"applicant_values.value_id = {value_id}"
+#         return sql_query
 
 class SearchResultsResource(Resource):
     """
@@ -56,7 +56,9 @@ class SearchResultsResource(Resource):
     def get(self, **kwargs):
         skill_ids = request.json['skills']
         value_ids = request.json['values']
-        sql_query = _create_sql_query(skill_ids, value_ids)
+
+        # sql_query = _create_sql_query(skill_ids, value_ids)
+        # import pdb; pdb.set_trace()
         if not skill_ids and not value_ids:
             return {
                 'success': False,
@@ -71,8 +73,11 @@ class SearchResultsResource(Resource):
         #         'errors': "skill_ids and value_ids keys must be present in request body."
         #     }, 400
         else:
-            filtered_applicants = db.engine.execute(sql_query)
-            search_results = [_applicant_payload(applicant) for applicant in filtered_applicants]
+            # filtered_applicants = db.engine.execute(sql_query)
+            # search_results = [_applicant_payload(applicant) for applicant in filtered_applicants]
+
+            applicants = db.session.query(Applicant).join(Skill, Applicant.skills).filter(Skill.id == 1)
+            search_results = [_applicant_payload(applicant) for applicant in applicants]
             return {
                 'success': True,
                 'data': search_results

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -11,14 +11,21 @@ from api.database.models import Applicant, Skill, Value
 
 # HELPER METHODS
 def _applicant_payload(applicant):
+    skills = []
+    for skill in applicant.skills:
+        skills.append({'attribute': skill.name})
+
+    values = []
+    for value in applicant.values:
+        values.append({'attribute': value.name})
 
     return {
         'id': applicant.id,
         'username': applicant.username,
         'email': applicant.email,
         'bio': applicant.bio,
-        'skills': [skill.name for skill in applicant.skills],
-        'values': [value.name for value in applicant.values],
+        'skills': skills,
+        'values': values,
     }
 
 def _filter_applicants(skill_ids, value_ids):

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -7,3 +7,14 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from api import db
 from api.database.models import Applicant
+
+def _search_results_payload(results):
+
+    return {
+        'id': applicant.id,
+        'username': applicant.username,
+        'email': applicant.email,
+        'bio': applicant.bio,
+        'skills': [skill.name for skill in applicant.skills],
+        'values': [value.name for value in applicant.values],
+    }

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -4,6 +4,7 @@ import json
 from flask import request
 from flask_restful import Resource, abort
 from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy import or_
 
 from api import db
 from api.database.models import Applicant, Skill, Value
@@ -22,7 +23,7 @@ def _applicant_payload(applicant):
 
 def _filter_applicants(skill_ids, value_ids):
     if skill_ids and value_ids:
-        applicants = None
+        applicants = db.session.query(Applicant).join(Skill, Applicant.skills).join(Value, Applicant.values).filter(or_(Skill.id.in_(skill_ids), Value.id.in_(value_ids)))
     elif skill_ids and not value_ids:
         applicants = db.session.query(Applicant).join(Skill, Applicant.skills).filter(Skill.id.in_(skill_ids))
     elif value_ids and not skill_ids:

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -20,6 +20,15 @@ def _applicant_payload(applicant):
         'values': [value.name for value in applicant.values],
     }
 
+def _filter_applicants(skill_ids, value_ids):
+    if skill_ids and value_ids:
+        applicants = None
+    elif skill_ids and not value_ids:
+        applicants = db.session.query(Applicant).join(Skill, Applicant.skills).filter(Skill.id.in_(skill_ids))
+    elif value_ids and not skill_ids:
+        applicants = db.session.query(Applicant).join(Value, Applicant.values).filter(Value.id.in_(value_ids))
+    return applicants
+
 class SearchResultsResource(Resource):
     """
     this Resource file is for our /applicants/search endpoint
@@ -29,8 +38,6 @@ class SearchResultsResource(Resource):
         skill_ids = request.json['skills']
         value_ids = request.json['values']
 
-        # sql_query = _create_sql_query(skill_ids, value_ids)
-        # import pdb; pdb.set_trace()
         if not skill_ids and not value_ids:
             return {
                 'success': False,
@@ -47,10 +54,8 @@ class SearchResultsResource(Resource):
         else:
             # filtered_applicants = db.engine.execute(sql_query)
             # search_results = [_applicant_payload(applicant) for applicant in filtered_applicants]
-
-            applicants_filtered_by_skills = db.session.query(Applicant).join(Skill, Applicant.skills).filter(Skill.id.in_(skill_ids))
-            import pdb; pdb.set_trace()
-            search_results = [_applicant_payload(applicant) for applicant in applicants]
+            filtered_applicants = _filter_applicants(skill_ids, value_ids)
+            search_results = [_applicant_payload(applicant) for applicant in filtered_applicants]
             return {
                 'success': True,
                 'data': search_results

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -20,34 +20,6 @@ def _applicant_payload(applicant):
         'values': [value.name for value in applicant.values],
     }
 
-# def _create_sql_query(skill_ids, value_ids):
-#     sql_query = "SELECT DISTINCT applicants.* FROM applicants JOIN applicant_skills ON applicants.id = applicant_skills.applicant_id JOIN applicant_values ON applicants.id = applicant_values.applicant_id WHERE "
-#     skill_ids_length = len(skill_ids) - 1
-#     value_ids_length = len(value_ids) - 1
-#     if skill_ids and value_ids:
-#         for skill_id in skill_ids:
-#             sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
-#         for value_id in value_ids:
-#             if value_id != value_ids[value_ids_length]:
-#                 sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
-#             else:
-#                 sql_query = sql_query + f"applicant_values.value_id = {value_id}"
-#         return sql_query
-#     elif skill_ids and not value_ids:
-#         for skill_id in skill_ids:
-#             if skill_id != skill_ids[skill_ids_length]:
-#                 sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
-#             else:
-#                 sql_query = sql_query + f"applicant_skills.skill_id = {skill_id}"
-#         return sql_query
-#     elif value_ids and not skill_ids:
-#         for value_id in value_ids:
-#             if value_id != value_ids[value_ids_length]:
-#                 sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
-#             else:
-#                 sql_query = sql_query + f"applicant_values.value_id = {value_id}"
-#         return sql_query
-
 class SearchResultsResource(Resource):
     """
     this Resource file is for our /applicants/search endpoint
@@ -82,3 +54,35 @@ class SearchResultsResource(Resource):
                 'success': True,
                 'data': search_results
             }, 200
+
+
+
+
+
+# def _create_sql_query(skill_ids, value_ids):
+#     sql_query = "SELECT DISTINCT applicants.* FROM applicants JOIN applicant_skills ON applicants.id = applicant_skills.applicant_id JOIN applicant_values ON applicants.id = applicant_values.applicant_id WHERE "
+#     skill_ids_length = len(skill_ids) - 1
+#     value_ids_length = len(value_ids) - 1
+#     if skill_ids and value_ids:
+#         for skill_id in skill_ids:
+#             sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
+#         for value_id in value_ids:
+#             if value_id != value_ids[value_ids_length]:
+#                 sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
+#             else:
+#                 sql_query = sql_query + f"applicant_values.value_id = {value_id}"
+#         return sql_query
+#     elif skill_ids and not value_ids:
+#         for skill_id in skill_ids:
+#             if skill_id != skill_ids[skill_ids_length]:
+#                 sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
+#             else:
+#                 sql_query = sql_query + f"applicant_skills.skill_id = {skill_id}"
+#         return sql_query
+#     elif value_ids and not skill_ids:
+#         for value_id in value_ids:
+#             if value_id != value_ids[value_ids_length]:
+#                 sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
+#             else:
+#                 sql_query = sql_query + f"applicant_values.value_id = {value_id}"
+#         return sql_query

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -52,43 +52,9 @@ class SearchResultsResource(Resource):
         #         'errors': "skill_ids and value_ids keys must be present in request body."
         #     }, 400
         else:
-            # filtered_applicants = db.engine.execute(sql_query)
-            # search_results = [_applicant_payload(applicant) for applicant in filtered_applicants]
             filtered_applicants = _filter_applicants(skill_ids, value_ids)
             search_results = [_applicant_payload(applicant) for applicant in filtered_applicants]
             return {
                 'success': True,
                 'data': search_results
             }, 200
-
-
-
-
-
-# def _create_sql_query(skill_ids, value_ids):
-#     sql_query = "SELECT DISTINCT applicants.* FROM applicants JOIN applicant_skills ON applicants.id = applicant_skills.applicant_id JOIN applicant_values ON applicants.id = applicant_values.applicant_id WHERE "
-#     skill_ids_length = len(skill_ids) - 1
-#     value_ids_length = len(value_ids) - 1
-#     if skill_ids and value_ids:
-#         for skill_id in skill_ids:
-#             sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
-#         for value_id in value_ids:
-#             if value_id != value_ids[value_ids_length]:
-#                 sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
-#             else:
-#                 sql_query = sql_query + f"applicant_values.value_id = {value_id}"
-#         return sql_query
-#     elif skill_ids and not value_ids:
-#         for skill_id in skill_ids:
-#             if skill_id != skill_ids[skill_ids_length]:
-#                 sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
-#             else:
-#                 sql_query = sql_query + f"applicant_skills.skill_id = {skill_id}"
-#         return sql_query
-#     elif value_ids and not skill_ids:
-#         for value_id in value_ids:
-#             if value_id != value_ids[value_ids_length]:
-#                 sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
-#             else:
-#                 sql_query = sql_query + f"applicant_values.value_id = {value_id}"
-#         return sql_query

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -1,0 +1,9 @@
+import datetime
+import json
+
+from flask import request
+from flask_restful import Resource, abort
+from sqlalchemy.orm.exc import NoResultFound
+
+from api import db
+from api.database.models import Applicant

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -10,7 +10,7 @@ from api.database.models import Applicant, ApplicantSkill, ApplicantValue
 
 # HELPER METHODS
 def _applicant_payload(applicant):
-
+    import pdb; pdb.set_trace()
     return {
         'id': applicant.id,
         'username': applicant.username,
@@ -72,8 +72,8 @@ class SearchResultsResource(Resource):
         #     }, 400
         else:
             filtered_applicants = db.engine.execute(sql_query)
-            search_results_payload = [_applicant_payload(applicant) for applicant in filtered_applicants]
+            search_results = [_applicant_payload(applicant) for applicant in filtered_applicants]
             return {
                 'success': True,
-                'data': search_results_payload
+                'data': search_results
             }, 200

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -48,7 +48,8 @@ class SearchResultsResource(Resource):
             # filtered_applicants = db.engine.execute(sql_query)
             # search_results = [_applicant_payload(applicant) for applicant in filtered_applicants]
 
-            applicants = db.session.query(Applicant).join(Skill, Applicant.skills).filter(Skill.id == 1)
+            applicants_filtered_by_skills = db.session.query(Applicant).join(Skill, Applicant.skills).filter(Skill.id.in_(skill_ids))
+            import pdb; pdb.set_trace()
             search_results = [_applicant_payload(applicant) for applicant in applicants]
             return {
                 'success': True,

--- a/api/resources/search_results.py
+++ b/api/resources/search_results.py
@@ -24,16 +24,20 @@ def _search_results_payload(filtered_applicants):
 def _create_sql_query(skill_ids, value_ids):
     sql_query = "SELECT DISTINCT applicants.* FROM applicants JOIN applicant_skills ON applicants.id = applicant_skills.applicant_id JOIN applicant_values ON applicants.id = applicant_values.applicant_id WHERE "
     skill_ids_length = len(skill_ids) - 1
-    value_ids_length = len(skill_ids) - 1
+    value_ids_length = len(value_ids) - 1
     if skill_ids and value_ids:
-        for i in range(skill_ids_length):
-            sql_query = sql_query + f"applicant_skills.skill_id = {skill_ids[i]} OR "
-        for i in range(value_ids_length):
-            if i != value_ids_length:
-                sql_query = sql_query + f"applicant_values.value_id - {value_ids[i]} OR "
+        for skill_id in skill_ids:
+        # for i in range(skill_ids_length):
+            sql_query = sql_query + f"applicant_skills.skill_id = {skill_id} OR "
+        for value_id in value_ids:
+        # for i, value_id in enumerate(value_ids):
+        # for i in range(value_ids_length):
+            # if value_ids[i + 1] != None:
+            if value_id != value_ids[value_ids_length]:
+                sql_query = sql_query + f"applicant_values.value_id = {value_id} OR "
             else:
-                sql_query = sql_query + f"applicant_values.value_id - {value_ids[i]}"
-    import pdb; pdb.set_trace()
+                sql_query = sql_query + f"applicant_values.value_id = {value_id}"
+            import pdb; pdb.set_trace()
 
 ####HAVING ISSUES WITH ITERATING THROUGH IDS AND PRODUCING SOMETHING DIFFERENT FOR LAST ID IN ARRAY
 


### PR DESCRIPTION
#### Type of Change Made 
- [X] new feature 
#### What's this PR do?
exposes the `/api/v1/applicants/search` endpoint
#### Where should the reviewer start?
take a look at the `api/resources/search_results.py` and the updated documentation
#### How should this be manually tested?
make sure to have the new `values` and `skills` seeded locally, add some additional `applicant_skills` and `applicant_values` records in your local database, and test out the following requests via postman:
```json
{"skills": [1, 15],
"values": [1]
    }
```
```json
{"skills": [],
"values": [1]
    }
```
```json
{"skills": [1],
"values": []
    }
```
```json
{"skills": [],
"values": []
    }
# this will produce a 400 response
```
#### Any background context you want to provide?
so glad to be done with this endpoint.....
for future reference, querying with raw SQL does not allow us to access nested objects ¯\_(ツ)_/¯ 
yay for SQLAlchemy (and I miss ActiveRecord)
#### What are the relevant tickets?
closes #27 
#### Screenshots (if appropriate)
as discussed in Slack, a successful response formats each applicant's skills and values as nested objects (reflecting the format that the rest of our responses will be updated to follow)
<img width="812" alt="Screen Shot 2020-11-01 at 11 54 06 PM" src="https://user-images.githubusercontent.com/62635544/97838821-3be1db00-1c9e-11eb-883d-ef5bcfd1a3f9.png">

and this is what the response looks like when a request body doesn't include any skill or value ids
<img width="960" alt="Screen Shot 2020-10-31 at 5 02 48 PM" src="https://user-images.githubusercontent.com/62635544/97838959-79deff00-1c9e-11eb-88a2-07f6ee51d430.png">
as indicated by the commented out code on lines 55-61 in `api/resources/search_results.py`, an additional error handling conditional can be added later
#### Questions:
