### PR TITLE
make post /messages validations more explicit

### DIFF
--- a/api/resources/messages.py
+++ b/api/resources/messages.py
@@ -78,14 +78,14 @@ class MessagesResource(Resource):
         errors = []
 
         # employer info can't be blank
-        proceed, employer_name, errors = _validate_field(
+        proceed1, employer_name, errors = _validate_field(
             data, 'employer_name', proceed, errors)
-        proceed, employer_email, errors = _validate_field(
+        proceed2, employer_email, errors = _validate_field(
             data, 'employer_email', proceed, errors)
-        proceed, applicant_id, errors = _validate_field(
+        proceed3, applicant_id, errors = _validate_field(
             data, 'applicant_id', proceed, errors)
-
-        if proceed:
+            
+        if proceed1 and proceed2 and proceed3:
             message = Message(
                 applicant_id=applicant_id,
                 employer_name=employer_name,


### PR DESCRIPTION
#### Type of Change Made  
- [x] bugfix 
#### What's this PR do?
- edited validations for POST messages to be more explicit by requiring all three `proceed` to be true in order to return a posted message result. 
- not sure why this is necessary, as it seems to work fine for posting applicants without this patch
- this is definitely a hacky solution, but it works, and I'm not sure what else to do at the moment. 
- the only thing that breaks it is if one of the fields comes in with 'null' (tested through postman) but i didn't add anything to account for it because we don't have that in applications either, and a field will ideally either be missing entirely from the request body, or come in as an empty string, both cases return errors.
#### Where should the reviewer start?
- resources/messages.py
#### How should this be manually tested?
- playing around with POST /messages endpoint in postman
#### Any background context you want to provide?
#### What are the relevant tickets?
closes #63 
#### Screenshots (if appropriate)
#### Questions:
