### PR TITLE
Create testing methods in manage.py and create .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,18 @@
+[run]
+omit =
+    .pytest_cache
+    run.py
+    manage.py
+    venv/*
+
+[report]
+omit =
+    .pytest_cache
+    run.py
+    manage.py
+    venv/*
+
+ignore_errors = True
+
+[html]
+directory = coverage_html_report

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## HireUp - Backend API in Flask 
+## HireUp - Backend API in Flask
 [![Build Status](https://travis-ci.org/HireUp-Turing/HireUp_backend.svg?branch=main)](https://travis-ci.org/HireUp-Turing/HireUp_backend)
 
 ### Set Up Flask App
@@ -32,7 +32,13 @@ _These instructions will be modified once an `.env` file is added to this repo._
 
 ### Running tests
 _more details to come_
-- `python -m pytest -v`
+- Run tests without coverage report: `$ python -m pytest -v`
+- Run tests with coverage report: `$ pytest --cov tests api`
+  - See browser-based coverage report
+    ```
+    $ coverage html
+    $ open coverage_html_report/index.html
+    ```
 
 ### Database Schema
 ![image](https://user-images.githubusercontent.com/62635544/96819356-a6626380-13e0-11eb-8398-eef92ca100f3.png)

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ _These instructions will be modified once an `.env` file is added to this repo._
 - _Coming soon... database migrate/seeding commands._
 
 ### Running tests
-_more details to come_
-- Run tests without coverage report: `$ python -m pytest -v`
+- Run tests without coverage report: `$ python -m pytest -v` or `$ python manage.py test`
 - Run tests with coverage report: `$ pytest --cov tests api`
   - See browser-based coverage report
     ```

--- a/manage.py
+++ b/manage.py
@@ -1,3 +1,6 @@
+import unittest
+import coverage
+
 # File to configure Manager from flask-script, which is like Rake tasks for Flask
 from flask_script import Manager
 # include the next line when dealing with migrations
@@ -314,6 +317,29 @@ def db_seed():
     # this is just a return value for confirmation.
     # counts objects seeded
     print(f'obj count: {len(db.session.query(Applicant).all())}')
+
+@manager.command
+def test():
+    """run tests without coverage"""
+    tests = unittest.TestLoader().discover('.')
+    unittest.TextTestRunner(verbosity=2).run(tests)
+
+@manager.command
+def cov():
+    """run unit tests with coverage"""
+    cov = coverage.coverage(branch=True, include='projects/*')
+    cov.start()
+    tests = unittest.TestLoader().discover('.')
+    unittest.TextTestRunner(verbosity=2).run(tests)
+    cov.stop()
+    cov.save()
+    print('Coverage Summary:')
+    cov.report()
+    basedir = os.path.abspath(os.path.dirname(__file__))
+    covdir = os.path.join(basedir, 'coverage')
+    cov.html_report(directory=covdir)
+    cov.erase()
+
 
 if __name__ == "__main__":
     manager.run()


### PR DESCRIPTION
#### Type of Change Made 
- [X] testing 
#### What's this PR do?
- adds `.coveragerc` file - I created this based on a handful of stackoverflow posts, test coverage guides, and Ian's example repo but have had a hard time tracking down what the actual purpose of this file is
- defines methods in `manage.py` for running our tests with and without coverage
py.test --cov-report term --cov api tests/
  - `$ pytest --cov tests api` or `$py.test --cov-report term --cov api tests/` - produces coverage report. different directories can be switched out for `api` within this command (e.g., `api/database`, `api/resources`, and `tests`. I'm not sure which is the "right" one to rely on, but they all seem to produce a higher than anticipated coverage percentage (ranging from 35% - 100%)
  - if you then run `$ coverage html` and `$ open coverage_html_report/index.html`, the coverage report will open up in the browser
- `$ python manage.py test` - runs tests without producing coverage report
#### What are the relevant tickets?
#47 
#### Screenshots (if appropriate)
#### Notes:
- I'm finding the percentages pretty suspicious and am trying to find some answers / direction for why the percentages are so high / if I'm testing this the right way / etc but at least it seems like we're not the only group running into this
- Jane mentioned her group is testing their endpoints via Postman. She didn't share any resources but from a quick search, [this](https://blog.postman.com/writing-tests-in-postman/) resource seems like it could be useful. I'm not sure I'll have a chance to implement this tomorrow but linking to it here just in case either of us do have capacity before code freeze