### PR TITLE
Test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,18 @@
+[run]
+omit =
+    .pytest_cache
+    run.py
+    manage.py
+    venv/*
+
+[report]
+omit =
+    .pytest_cache
+    run.py
+    manage.py
+    venv/*
+
+ignore_errors = True
+
+[html]
+directory = coverage_html_report

--- a/README.md
+++ b/README.md
@@ -49,16 +49,18 @@ HireUp aims to minimize bias in the hiring process, and reduce efforts required 
   ```
 - `$ python run.py` to run server on `localhost:5000` (_If you get errors concerning the `FLASK_APP` environment not being set, try `$ export FLASK_APP=manage.py`_)
 
-<!-- _These instructions will be modified once an `.env` file is added to this repo._ -->
-
 ## CLI commands
 - `$ python manage.py routes` returns available routes
 - _Coming soon... database migrate/seeding commands._
 
 ## Testing
-_more details to come_
-_add info about coverage_
-- Run tests: `python -m pytest -v`
+- Run tests without coverage: `$ python -m pytest -v`
+- Run tests with coverage report: `$ pytest --cov tests api`
+  - See browser-based coverage report
+    ```
+    $ coverage html
+    $ open coverage_html_report/index.html
+    ```
 
 ## Database Schema
 ![image](https://user-images.githubusercontent.com/62635544/97842714-49e72a00-1ca5-11eb-8787-f188eb7d8ed3.png)

--- a/api/resources/messages.py
+++ b/api/resources/messages.py
@@ -78,14 +78,14 @@ class MessagesResource(Resource):
         errors = []
 
         # employer info can't be blank
-        proceed, employer_name, errors = _validate_field(
+        proceed1, employer_name, errors = _validate_field(
             data, 'employer_name', proceed, errors)
-        proceed, employer_email, errors = _validate_field(
+        proceed2, employer_email, errors = _validate_field(
             data, 'employer_email', proceed, errors)
-        proceed, applicant_id, errors = _validate_field(
+        proceed3, applicant_id, errors = _validate_field(
             data, 'applicant_id', proceed, errors)
-
-        if proceed:
+            
+        if proceed1 and proceed2 and proceed3:
             message = Message(
                 applicant_id=applicant_id,
                 employer_name=employer_name,

--- a/manage.py
+++ b/manage.py
@@ -1,3 +1,6 @@
+import unittest
+import coverage
+
 # File to configure Manager from flask-script, which is like Rake tasks for Flask
 from flask_script import Manager
 # include the next line when dealing with migrations
@@ -314,6 +317,29 @@ def db_seed():
     # this is just a return value for confirmation.
     # counts objects seeded
     print(f'obj count: {len(db.session.query(Applicant).all())}')
+
+@manager.command
+def test():
+    """run tests without coverage"""
+    tests = unittest.TestLoader().discover('.')
+    unittest.TextTestRunner(verbosity=2).run(tests)
+
+@manager.command
+def cov():
+    """run unit tests with coverage"""
+    cov = coverage.coverage(branch=True, include='projects/*')
+    cov.start()
+    tests = unittest.TestLoader().discover('.')
+    unittest.TextTestRunner(verbosity=2).run(tests)
+    cov.stop()
+    cov.save()
+    print('Coverage Summary:')
+    cov.report()
+    basedir = os.path.abspath(os.path.dirname(__file__))
+    covdir = os.path.join(basedir, 'coverage')
+    cov.html_report(directory=covdir)
+    cov.erase()
+
 
 if __name__ == "__main__":
     manager.run()


### PR DESCRIPTION
#### Type of Change Made 
- [X] testing 
#### What's this PR do?
- adds `.coveragerc` file - I created this based on a handful of stackoverflow posts, test coverage guides, and Ian's example repo but have had a hard time tracking down what the actual purpose of this file is
- defines methods in `manage.py` for running our tests with and without coverage
py.test --cov-report term --cov api tests/
  - `$ pytest --cov tests api` or `$py.test --cov-report term --cov api tests/` - produces coverage report. different directories can be switched out for `api` within this command (e.g., `api/database`, `api/resources`, and `tests`. I'm not sure which is the "right" one to rely on, but they all seem to produce a higher than anticipated coverage percentage (ranging from 35% - 100%)
  - if you then run `$ coverage html` and `$ open coverage_html_report/index.html`, the coverage report will open up in the browser
- `$ python manage.py test` - runs tests without producing coverage report
#### What are the relevant tickets?
#47 
#### Screenshots (if appropriate)
this is what the coverage report looks like via CLI
![](https://user-images.githubusercontent.com/62635544/97924805-7b034100-1d1d-11eb-88cb-4372986bc015.png)

#### Notes:
- I'm finding the percentages pretty suspicious and am trying to find some answers / direction for why the percentages are so high / if I'm testing this the right way / etc but at least it seems like we're not the only group running into this
- Jane mentioned her group is testing their endpoints via Postman. She didn't share any resources but from a quick search, [this](https://blog.postman.com/writing-tests-in-postman/) resource seems like it could be useful. I'm not sure I'll have a chance to implement this tomorrow but linking to it here just in case either of us do have capacity before code freeze