### PR TITLE
Update format of skills and values in _applicant_payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This repo is the back-end service for HireUp and is consumed by our front-end ap
       "first_name": "Greyson",
       "last_name": "Johns",
       "bio": "I'm the best one you could possibly hire",
+      "email": "greyson@gmail.com",
       "username": "Chipmunk",
       "skills": [2, 3],
       "values": [2]

--- a/api/resources/applicants.py
+++ b/api/resources/applicants.py
@@ -11,14 +11,20 @@ from api.database.models import Applicant, ApplicantSkill, ApplicantValue
 
 # HELPER METHODS
 def _applicant_payload(applicant):
+    skills = []
+    for skill in applicant.skills:
+        skills.append({'attribute': skill.name})
+
+    values = []
+    for value in applicant.values:
+        values.append({'attribute': value.name})
 
     return {
         'id': applicant.id,
         'username': applicant.username,
         'bio': applicant.bio,
-        # 'skills': [{'id': skill.id, 'name': skill.name} for skill in applicant.skills],
-        'skills': [skill.name for skill in applicant.skills],
-        'values': [value.name for value in applicant.values],
+        'skills': skills,
+        'values': values,
     }
 
 def _validate_field(data, field, proceed, errors, missing_okay=False):

--- a/tests/test_post_applicant.py
+++ b/tests/test_post_applicant.py
@@ -19,9 +19,9 @@ class PostApplicantTest(unittest.TestCase):
         self.app_context.pop()
 
     def test_create_new_applicant(self):
-        skill = Skill(name='skill')
+        skill = Skill(name='rails')
         db.session.add(skill)
-        value = Value(name='value')
+        value = Value(name='collaboration')
         db.session.add(value)
 
         new_data = {
@@ -43,12 +43,13 @@ class PostApplicantTest(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
 
         self.assertEqual(1, data['data']['id'])
-        self.assertEqual(['skill'], data['data']['skills'])
+        self.assertEqual('rails', data['data']['skills'][0]['attribute'])
+        self.assertEqual('collaboration', data['data']['values'][0]['attribute'])
 
     def test_sadpath_create_new_applicant(self):
-        skill = Skill(name='skill')
+        skill = Skill(name='rails')
         db.session.add(skill)
-        value = Value(name='value')
+        value = Value(name='collaboration')
         db.session.add(value)
 
         new_data = {


### PR DESCRIPTION
#### Type of Change Made 
- [x] bugfix 
- [x] formatting 
#### What's this PR do?
Updates formatting of response payloads containing skills and values data: data was previously returned as array of strings; now returned as array of objects with `attribute` as key pointing to individual skills and values
#### Where should the reviewer start?
only change made is in `api/resources/applicants.py`
#### Any background context you want to provide?
- change requested by FE for typescript
- see #82
#### What are the relevant tickets?
closes #84 
#### Screenshots (if appropriate)
#### Questions:
